### PR TITLE
[EI-27] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository serves as a one-stop shop for integrating your WordPress site on
 
 Adding Edge Integrations support to your Integrated Composer project is simple and is the recommended means of adding the Edge Integrations WordPress SDK.
 
-#### Step 1: Require the Composer package
+#### Requiring the Composer package
 
 To get started, all you need to do is to add this repository as a dependency:
 
@@ -22,15 +22,13 @@ composer require pantheon-systems/edge-integrations-wordpress-sdk
 
 That command will add this repository to your `/vendor` directory, as well as all of the dependencies, which include a [global, CMS-agnostic PHP library](https://github.com/pantheon-systems/pantheon-edge-integrations) and a [WordPress plugin](https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations) as well as all of the documentation for the SDK.
 
-#### Step 2: Require the Composer autoloader
-
-You'll need to make sure your WordPress project is loading the Composer autoloader (`vendor/composer/autoload.php`). One way to do this is in a `mu-plugins` loader file like [this one](https://github.com/pantheon-systems/wordpress-bedrock-recommended/blob/master/packages/pantheon-wp-loader/loader.php) <!-- TODO: Update this link when this is broken out into a new repository -->, but other methods exist, such as adding an `include_once __DIR__ . '/vendor/composer/autoload.php` line in your `wp-config.php` or other file that runs before WordPress is executed.
+Alternately, you can add `pantheon-systems/edge-integrations-wordpress-sdk` as a dependency to your project's `composer.json` file and run `composer install`.
 
 ### Installing manually
 
 If you aren't running a project with Integrated Composer but you _do_ use Composer otherwise, you can still get started with the Edge Integrations WordPress SDK without too much trouble. This still assumes you have Composer installed on at least one machine.
 
-#### Step 1: Clone the WordPress Edge Integrations plugin
+#### Step 1: Clone or `composer require` the WordPress Edge Integrations plugin
 
 First, you'll need to get a copy of the [WordPress Edge Integrations plugin](https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations). Clone or download the plugin into your `wp-content/plugins` directory.
 
@@ -53,15 +51,4 @@ cd pantheon-wordpress-edge-integrations
 composer install
 ```
 
-This will install `pantheon-edge-integrations` into the plugin's `vendor` directory. You'll still need to call the file(s) manually. <!-- TODO: Is this 100% accurate? We can maybe run a <?php if ( ! class_exists( 'HeaderData' ) ) ?> check in the plugin to see if we have the package and either display a message, attempt to load it manually, or bail otherwise. -->
-
-Using a `mu-plugins/loader.php` file like the one linked above, add the Composer `autoload.php` file from the plugin to the `$mu_plugins` list. <!-- TODO: Validate that this still works. -->
-
-```php
-// Add your mu-plugins here.
-$mu_plugins = [
-	'/../plugins/pantheon-wordpress-edge-integrations/vendor/composer/autoload.php',
-];
-```
-
-Requiring the `autoload.php` file from inside the plugin will ensure that any files that are autoloaded using Composer will be loaded into WordPress. Alternately, you can `require` this file anywhere in your project that makes sense, for example, in a `wp-config.php` file or some file that's included from `wp-config`, as long as it is available before `plugins_loaded`.
+This will install `pantheon-edge-integrations` into the plugin's `vendor` directory. The plugin itself will handle loading the library if it's installed.


### PR DESCRIPTION
This PR removes references to mu-plugin loader file.

We don't need to use a loader file anymore since the plugin includes the composer autoloader if it isn't already loaded.