### PR TITLE
[EI-68] add conn-speed and conn-type to filter example

### DIFF
--- a/docs/geo.md
+++ b/docs/geo.md
@@ -139,6 +139,8 @@ function filter_geo_allowed_values( array $values ) : array {
 	unset( $values['lat'] );
 	unset( $values['lon'] );
 	unset( $values['latlon'] );
+	unset( $values['conn-speed'] );
+	unset( $values['conn-type'] );
 	return $values;
 }
 ```


### PR DESCRIPTION
This PR adds the `conn-speed` and `conn-type` to the code snippet of parameters that can be removed.