### PR TITLE
[EI-243] API SDK docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,9 +48,11 @@ Interests can be tested or verified in two different ways.
 
 ### More Resources
 
-- [API](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/blob/master/docs/api.md)
+- [Main](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/blob/master/docs/main.md)
 
 - [Analytics](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/blob/main/docs/analytics.md)
+
+- [API](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/blob/main/docs/api.md)
 
 - [Geolocation](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/blob/main/docs/geo.md)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,3 +212,38 @@ The current user interest.
 **Return Type:** _string_
 
 [Reference](https://pantheon.stoplight.io/docs/edge-integrations/d50bfdfaea613-ei-user-interest)
+
+## Function Reference
+
+**Note:** The design of the API endpoints is to expose and reflect back data that can be retrieved using various PHP functions in the plugin and the endpoint callback functions use those to return data. It is advisable to use the originating functions themselves rather than the API functions unless you are explicitly interacting with the WordPress Edge Integrations API.
+
+### `API\get_all_user_data`
+
+Return the current user's personalization data.
+
+#### Parameters
+
+`$request` _(WP\_REST\_Request)_ The REST API request.
+
+#### Return
+
+The current user's personalization data. If a `WP_REST_Request` was passed, the personalization data is passed with the passed arguments from the request.
+
+#### Example
+
+```
+use Pantheon\EI\WP\API;
+use WP_REST_Request;
+
+$request = new WP_REST_Request( 'GET', '/pantheon/v1/ei/user' );
+$request->set_query_params( [
+	'interest' => 'foo',
+	'country-code' => 'US',
+] );
+
+$response = rest_do_request( $request );
+$country_code = 'country-code'; // Storing the parameter into a variable allows requests to be made with that parameter via PHP.
+
+$country = get_all_user_data( $request )->geo-$country_code; // Returns "US".
+$interest = get_all_user_data( $request )->interest; // Returns "foo".
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -358,11 +358,7 @@ _(string)_
 
 ## Function Reference
 
-<Alert title="Note"  type="info" >
-
-The purpse of the API endpoints is to expose and reflect data that can be retrieved using various PHP functions in the plugin, as well as the endpoint callback functions used those to return data. We advise that you use the originating functions rather than the API functions, unless you are explicitly interacting with the WordPress Edge Integrations API.
-
-</Alert>
+**Note:** The purpse of the API endpoints is to expose and reflect data that can be retrieved using various PHP functions in the plugin, as well as the endpoint callback functions used those to return data. We advise that you use the originating functions rather than the API functions, unless you are explicitly interacting with the WordPress Edge Integrations API.
 
 ### `API\get_all_user_data`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,81 +41,152 @@ _(object)_
 
 Current Edge Integrations configuration.
 
-**Return Type:** _object_
+#### Return
+_(object)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/edaa3dbe9bca3-ei-config)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/config`
+
+#### Reference
+
+[`pantheon/v1/ei/config`](https://pantheon.stoplight.io/docs/edge-integrations/edaa3dbe9bca3-ei-config)
 
 ### `pantheon/v1/ei/config/geo/allowed`
 
 Edge Integrations Geolocation configuration settings.
 
-**Return Type:** _array_
+#### Return
+_(array)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/96585a3c74391-ei-config-geo-allowed)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/config/geo/allowed`
+
+#### Reference
+
+[`pantheon/v1/ei/config/geo/allowed`]
+(https://pantheon.stoplight.io/docs/edge-integrations/96585a3c74391-ei-config-geo-allowed)
 
 ### `pantheon/v1/ei/config/interest/cookie-expiration`
 
 The interest cookie expiration in days.
 
-**Return Type:** _int_
+#### Return
+_(int)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/15b15bd2b7eff-ei-config-interest-cookie-expiration)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/config/interest/cookie-expiration`
+
+#### Reference
+
+[`pantheon/v1/ei/config/interest/cookie-expiration`](https://pantheon.stoplight.io/docs/edge-integrations/15b15bd2b7eff-ei-config-interest-cookie-expiration)
 
 ### `pantheon/v1/ei/config/interest/post-types`
 
 The currently enabled post types for interest tracking.
 
-**Return Type:** _array_
+#### Return
+_(array)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/c5db87f36cc21-ei-config-interest-post-types)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/config/interest/post-types`
+
+#### Reference
+
+[`pantheon/v1/ei/config/interest/post-types`](https://pantheon.stoplight.io/docs/edge-integrations/c5db87f36cc21-ei-config-interest-post-types)
 
 ### `pantheon/v1/ei/config/interest/taxonomies`
 
 The current list of enabled taxonomies for Edge Integrations interest tracking.
 
-**Return Type:** _array_
+#### Return
+_(array)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/fb47b8ec8fa31-ei-config-interest-taxonomies)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/config/interest/taxonomies`
+
+#### Reference
+
+[`pantheon/v1/ei/config/interest/taxonomies`](https://pantheon.stoplight.io/docs/edge-integrations/fb47b8ec8fa31-ei-config-interest-taxonomies)
 
 ### `pantheon/v1/ei/config/interest/threshold`
 
 The Edge Integrations interest tracking threshold.
 
-**Return Type:** _int_
+#### Return
+_(int)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/970ac042750be-ei-config-interest-threshold)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/config/interest/threshold`
+
+#### Reference
+
+[`pantheon/v1/ei/config/interest/threshold`](https://pantheon.stoplight.io/docs/edge-integrations/970ac042750be-ei-config-interest-threshold)
 
 ### `pantheon/v1/ei/segments`
 
 Returns a list of enabled segments for personalization.
 
-**Return Type:** _object_
+#### Return
+_(object)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/48045c3028625-ei-segments)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/segments`
+
+#### Reference
+
+[`pantheon/v1/ei/segments`](https://pantheon.stoplight.io/docs/edge-integrations/48045c3028625-ei-segments)
 
 ### `pantheon/v1/ei/segments/connection`
 
 The list of available connection segments.
 
-**Return Type:** _array_
+#### Return
+_(array)_
 
-[Reference]()
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/segments/connection`
+
+#### Reference
+
+[`pantheon/v1/ei/segments/connection`](https://pantheon.stoplight.io/docs/edge-integrations/f8f8f8f8f8f8f-ei-segments-connection)
 
 ### `pantheon/v1/ei/segments/geo`
 
 The list of available geolocation segments.
 
-**Return Type:** _array_
+#### Return
+_(array)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/68d178a2e5511-ei-segments-geo)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/segments/geo`
+
+#### Reference
+
+[`pantheon/v1/ei/segments/geo`](https://pantheon.stoplight.io/docs/edge-integrations/68d178a2e5511-ei-segments-geo)
 
 ### `pantheon/v1/ei/segments/interests`
 
 The list of available interest terms based on the enabled interest taxonomies.
 
-**Return Type:** _array_
+#### Return
+_(array)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/79cac6693543c-ei-segments-interests)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/segments/interests`
+
+#### Reference
+
+[`pantheon/v1/ei/segments/interests`](https://pantheon.stoplight.io/docs/edge-integrations/79cac6693543c-ei-segments-interests)
 
 ### `pantheon/v1/ei/user`
 
@@ -157,69 +228,121 @@ The region of the user.
 
 The user's interest.
 
-**Return Type:** _object_
+#### Return
+_(object)_
 
 #### Example
 
 `GET https://domain.com/wp-json/pantheon/v1/ei/user?interest=foo&country-code=US`
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/9adbc8702b480-ei-user)
+#### Reference
+
+[`pantheon/v1/ei/user`](https://pantheon.stoplight.io/docs/edge-integrations/9adbc8702b480-ei-user)
 
 ### `pantheon/v1/ei/user/conn-speed`
 
 Current user connection speed.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/df582b33b8768-ei-user-conn-speed)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/conn-speed`
+
+#### Reference
+
+[`pantheon/v1/ei/user/conn-speed`](https://pantheon.stoplight.io/docs/edge-integrations/df582b33b8768-ei-user-conn-speed)
 
 ### `pantheon/v1/ei/user/conn-type`
 
 The current user connection type.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/eb8e9ddfc5c03-ei-user-conn-type)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/conn-type`
+
+#### Reference
+
+[`pantheon/v1/ei/user/conn-type`](https://pantheon.stoplight.io/docs/edge-integrations/eb8e9ddfc5c03-ei-user-conn-type)
 
 ### `pantheon/v1/ei/user/geo/city`
 
 The current user city.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/dfa8f040f1594-ei-user-geo-city)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/geo/city`
+
+#### Reference
+
+[`pantheon/v1/ei/user/geo/city`](https://pantheon.stoplight.io/docs/edge-integrations/dfa8f040f1594-ei-user-geo-city)
 
 ### `pantheon/v1/ei/user/geo/country-code`
 
 The current user country code.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/geo/country-code`
+
+#### Reference
+
+[`pantheon/v1/ei/user/geo/country-code`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
 
 ### `pantheon/v1/ei/user/geo/country-name`
 
 The current user country name.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/geo/country-name`
+
+#### Reference
+
+[`pantheon/v1/ei/user/geo/country-name`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
 
 ### `pantheon/v1/ei/user/geo/region`
 
 The current user's region, state, or province.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-region)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/geo/region`
+
+#### Reference
+
+[`pantheon/v1/ei/user/geo/region`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-region)
 
 ### `pantheon/v1/ei/user/interest`
 
 The current user interest.
 
-**Return Type:** _string_
+#### Return
+_(string)_
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d50bfdfaea613-ei-user-interest)
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user/interest`
+
+#### Reference
+
+[`pantheon/v1/ei/user/interest`](https://pantheon.stoplight.io/docs/edge-integrations/d50bfdfaea613-ei-user-interest)
 
 ## Function Reference
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,6 +85,14 @@ Returns a list of enabled segments for personalization.
 
 [Reference](https://pantheon.stoplight.io/docs/edge-integrations/48045c3028625-ei-segments)
 
+### `pantheon/v1/ei/segments/connection`
+
+The list of available connection segments.
+
+**Return Type:** _array_
+
+[Reference]()
+
 ### `pantheon/v1/ei/segments/geo`
 
 The list of available geolocation segments.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,202 @@
+# WordPress Edge Integrations: API
+
+## Namespace: `Pantheon\EI\WP\API`
+
+The namespace for the API functionality is `Pantheon\EI\WP\API`. When using functions that are part of this namespace, it is recommended that you `use` the namespace at the top of your file.
+
+```php
+use Pantheon\EI\WP\API;
+```
+
+Doing this allows you to use the functions without the full namespace prefix. 
+
+**More information**
+
+* [Namespaces](https://www.php.net/manual/en/language.namespaces.php) (php.net)
+* [Namespace and Function Imports](https://engineering.hmn.md/standards/style/php/#namespace-and-function-imports) (engineering.hmn.md/standards)
+
+## API Documentation and Testing
+
+Full documentation on the API endpoints and access to test responses is available on [Stoplight](https://pantheon.stoplight.io/docs/edge-integrations/fed9ddb2a5046-ei).
+
+## Endpoint reference
+
+### `pantheon/v1/ei`
+
+The main Pantheon Edge Integrations API endpoint.
+
+**Return Type:** _object_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/0cda792ad26fe-ei)
+
+### `pantheon/v1/ei/config`
+
+Current Edge Integrations configuration.
+
+**Return Type:** _object_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/edaa3dbe9bca3-ei-config)
+
+### `pantheon/v1/ei/config/geo/allowed`
+
+Edge Integrations Geolocation configuration settings.
+
+**Return Type:** _array_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/96585a3c74391-ei-config-geo-allowed)
+
+### `pantheon/v1/ei/config/interest/cookie-expiration`
+
+The interest cookie expiration in days.
+
+**Return Type:** _int_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/15b15bd2b7eff-ei-config-interest-cookie-expiration)
+
+### `pantheon/v1/ei/config/interest/post-types`
+
+The currently enabled post types for interest tracking.
+
+**Return Type:** _array_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/c5db87f36cc21-ei-config-interest-post-types)
+
+### `pantheon/v1/ei/config/interest/taxonomies`
+
+The current list of enabled taxonomies for Edge Integrations interest tracking.
+
+**Return Type:** _array_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/fb47b8ec8fa31-ei-config-interest-taxonomies)
+
+### `pantheon/v1/ei/config/interest/threshold`
+
+The Edge Integrations interest tracking threshold.
+
+**Return Type:** _int_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/970ac042750be-ei-config-interest-threshold)
+
+### `pantheon/v1/ei/segments`
+
+Returns a list of enabled segments for personalization.
+
+**Return Type:** _object_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/48045c3028625-ei-segments)
+
+### `pantheon/v1/ei/segments/geo`
+
+The list of available geolocation segments.
+
+**Return Type:** _array_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/68d178a2e5511-ei-segments-geo)
+
+### `pantheon/v1/ei/segments/interests`
+
+The list of available interest terms based on the enabled interest taxonomies.
+
+**Return Type:** _array_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/79cac6693543c-ei-segments-interests)
+
+### `pantheon/v1/ei/user`
+
+Current Edge Integrations client data.
+
+#### Query parameters
+
+All the Edge Integrations user endpoints can have any of the following query parameters added to the URL to return the specified data.
+
+##### `city`
+
+The city of the user.
+
+##### `conn-speed`
+
+The connection speed of the user.
+
+##### `conn-type`
+
+The connection type of the user.
+
+##### `continent-code`
+
+The continent code of the user.
+
+##### `country-code`
+
+The country code of the user.
+
+##### `country-name`
+
+The country name of the user.
+
+##### `region`
+
+The region of the user.
+
+##### `interest`
+
+The user's interest.
+
+**Return Type:** _object_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/9adbc8702b480-ei-user)
+
+### `pantheon/v1/ei/user/conn-speed`
+
+Current user connection speed.
+
+**Return Type:** _string_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/df582b33b8768-ei-user-conn-speed)
+
+### `pantheon/v1/ei/user/conn-type`
+
+The current user connection type.
+
+**Return Type:** _string_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/eb8e9ddfc5c03-ei-user-conn-type)
+
+### `pantheon/v1/ei/user/geo/city`
+
+The current user city.
+
+**Return Type:** _string_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/dfa8f040f1594-ei-user-geo-city)
+
+### `pantheon/v1/ei/user/geo/country-code`
+
+The current user country code.
+
+**Return Type:** _string_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
+
+### `pantheon/v1/ei/user/geo/country-name`
+
+The current user country name.
+
+**Return Type:** _string_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
+
+### `pantheon/v1/ei/user/geo/region`
+
+The current user's region, state, or province.
+
+**Return Type:** __
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-region)
+
+### `pantheon/v1/ei/user/interest`
+
+The current user interest.
+
+**Return Type:** _string_
+
+[Reference](https://pantheon.stoplight.io/docs/edge-integrations/d50bfdfaea613-ei-user-interest)

--- a/docs/api.md
+++ b/docs/api.md
@@ -201,7 +201,7 @@ The current user country name.
 
 The current user's region, state, or province.
 
-**Return Type:** __
+**Return Type:** _string_
 
 [Reference](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-region)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -151,6 +151,10 @@ The user's interest.
 
 **Return Type:** _object_
 
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei/user?interest=foo&country-code=US`
+
 [Reference](https://pantheon.stoplight.io/docs/edge-integrations/9adbc8702b480-ei-user)
 
 ### `pantheon/v1/ei/user/conn-speed`

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,10 +10,7 @@ use Pantheon\EI\WP\API;
 
 Doing this allows you to use the functions without the full namespace prefix. 
 
-**More information**
-
-* [Namespaces](https://www.php.net/manual/en/language.namespaces.php) (php.net)
-* [Namespace and Function Imports](https://engineering.hmn.md/standards/style/php/#namespace-and-function-imports) (engineering.hmn.md/standards)
+For more information on this, you may refer to: [Namespaces](https://www.php.net/manual/en/language.namespaces.php)(php.net), or [Namespace and Function Imports](https://engineering.hmn.md/standards/style/php/#namespace-and-function-imports) (engineering.hmn.md/standards).
 
 ## API Documentation and Testing
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,9 +25,17 @@ Full documentation on the API endpoints and access to test responses is availabl
 
 The main Pantheon Edge Integrations API endpoint.
 
-**Return Type:** _object_
+#### Return
 
-[Reference](https://pantheon.stoplight.io/docs/edge-integrations/0cda792ad26fe-ei)
+_(object)_
+
+#### Example
+
+`GET https://domain.com/wp-json/pantheon/v1/ei`
+
+#### Reference
+
+[`pantheon/v1/ei`](https://pantheon.stoplight.io/docs/edge-integrations/0cda792ad26fe-ei)
 
 ### `pantheon/v1/ei/config`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,7 +19,7 @@ Doing this allows you to use the functions without the full namespace prefix.
 
 Full documentation on the API endpoints and access to test responses is available on [Stoplight](https://pantheon.stoplight.io/docs/edge-integrations/fed9ddb2a5046-ei).
 
-## Endpoint reference
+## Endpoint Reference
 
 ### `pantheon/v1/ei`
 
@@ -42,6 +42,7 @@ _(object)_
 Current Edge Integrations configuration.
 
 #### Return
+
 _(object)_
 
 #### Example
@@ -103,6 +104,7 @@ _(array)_
 The current list of enabled taxonomies for Edge Integrations interest tracking.
 
 #### Return
+
 _(array)_
 
 #### Example
@@ -163,6 +165,7 @@ _(array)_
 The list of available geolocation segments.
 
 #### Return
+
 _(array)_
 
 #### Example
@@ -178,6 +181,7 @@ _(array)_
 The list of available interest terms based on the enabled interest taxonomies.
 
 #### Return
+
 _(array)_
 
 #### Example
@@ -192,7 +196,7 @@ _(array)_
 
 Current Edge Integrations client data.
 
-#### Query parameters
+#### Query Parameters
 
 All the Edge Integrations user endpoints can have any of the following query parameters added to the URL to return the specified data.
 
@@ -229,6 +233,7 @@ The region of the user.
 The user's interest.
 
 #### Return
+
 _(object)_
 
 #### Example
@@ -244,6 +249,7 @@ _(object)_
 Current user connection speed.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -259,6 +265,7 @@ _(string)_
 The current user connection type.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -274,6 +281,7 @@ _(string)_
 The current user city.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -289,6 +297,7 @@ _(string)_
 The current user country code.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -304,6 +313,7 @@ _(string)_
 The current user country name.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -319,6 +329,7 @@ _(string)_
 The current user's region, state, or province.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -334,6 +345,7 @@ _(string)_
 The current user interest.
 
 #### Return
+
 _(string)_
 
 #### Example
@@ -346,7 +358,11 @@ _(string)_
 
 ## Function Reference
 
-**Note:** The design of the API endpoints is to expose and reflect back data that can be retrieved using various PHP functions in the plugin and the endpoint callback functions use those to return data. It is advisable to use the originating functions themselves rather than the API functions unless you are explicitly interacting with the WordPress Edge Integrations API.
+<Alert title="Note"  type="info" >
+
+The purpse of the API endpoints is to expose and reflect data that can be retrieved using various PHP functions in the plugin, as well as the endpoint callback functions used those to return data. We advise that you use the originating functions rather than the API functions, unless you are explicitly interacting with the WordPress Edge Integrations API.
+
+</Alert>
 
 ### `API\get_all_user_data`
 
@@ -358,7 +374,7 @@ Return the current user's personalization data.
 
 #### Return
 
-The current user's personalization data. If a `WP_REST_Request` was passed, the personalization data is passed with the passed arguments from the request.
+The current user's personalization data. If a `WP_REST_Request` was passed, the personalization data is passed with the arguments that were passed in the request.
 
 #### Example
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -156,7 +156,7 @@ _(array)_
 
 #### Reference
 
-[`pantheon/v1/ei/segments/connection`](https://pantheon.stoplight.io/docs/edge-integrations/f8f8f8f8f8f8f-ei-segments-connection)
+[`pantheon/v1/ei/segments/connection`](https://pantheon.stoplight.io/docs/edge-integrations/be2e42421ddde-ei-segments-connection)
 
 ### `pantheon/v1/ei/segments/geo`
 
@@ -297,7 +297,7 @@ _(string)_
 
 #### Reference
 
-[`pantheon/v1/ei/user/geo/country-code`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
+[`pantheon/v1/ei/user/geo/country-code`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country-code)
 
 ### `pantheon/v1/ei/user/geo/country-name`
 
@@ -312,7 +312,7 @@ _(string)_
 
 #### Reference
 
-[`pantheon/v1/ei/user/geo/country-name`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-country)
+[`pantheon/v1/ei/user/geo/country-name`](https://pantheon.stoplight.io/docs/edge-integrations/69ec8d44d9c66-ei-user-geo-country-name)
 
 ### `pantheon/v1/ei/user/geo/region`
 
@@ -327,7 +327,7 @@ _(string)_
 
 #### Reference
 
-[`pantheon/v1/ei/user/geo/region`](https://pantheon.stoplight.io/docs/edge-integrations/d869daad71b8d-ei-user-geo-region)
+[`pantheon/v1/ei/user/geo/region`](https://pantheon.stoplight.io/docs/edge-integrations/477a8bed67b7c-ei-user-geo-region)
 
 ### `pantheon/v1/ei/user/interest`
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -2,7 +2,7 @@
 
 ## Namespace: `Pantheon\EI\WP`
 
-The base namespace for the WordPress Edge Integrations plugin is `Pantheon\EI\WP`. When using functions that are part of this namespace, it is recommended that you `use` the namespace at the top of your file.
+The base namespace for the WordPress Edge Integrations plugin is `Pantheon\EI\WP`. When using functions that are part of this namespace, it is recommended that you `use` the namespace at the top of your file. For example:
 
 ```php
 use Pantheon\EI\WP;
@@ -10,11 +10,9 @@ use Pantheon\EI\WP;
 
 Doing this allows you to use the functions without the full namespace prefix. 
 
-**More information**
-* [Namespaces](https://www.php.net/manual/en/language.namespaces.php) (php.net)
-* [Namespace and Function Imports](https://engineering.hmn.md/standards/style/php/#namespace-and-function-imports) (engineering.hmn.md/standards)
+For more information on this, you may refer to: [Namespaces](https://www.php.net/manual/en/language.namespaces.php)(php.net), or [Namespace and Function Imports](https://engineering.hmn.md/standards/style/php/#namespace-and-function-imports)(engineering.hmn.md/standards).
 
-## Constant reference
+## Constant Reference
 
 ### `PANTHEON_EDGE_INTEGRATIONS_DIR`
 
@@ -28,25 +26,41 @@ The path to the Pantheon Edge Integrations main plugin file.
 
 The current version of the Pantheon Edge Integrations plugin.
 
-## Function reference
+## Function Reference
 
 ### `WP\get_supported_vary_headers`
 
-Gets an array of the vary headers supported by the plugin. Before returning the array of vary headers, the [`pantheon.ei.supported_vary_headers`](#pantheoneisupportedvaryheaders) filter is applied. Only the headers (the _keys_ of `pantheon.ei.supported_vary_headers`) are returned.
+Gets an array of the vary headers supported by the plugin. Before returning the array of vary headers, the [`pantheon.ei.supported_vary_headers`](#pantheoneisupportedvaryheaders) filter is applied. Only the headers- or the _keys_ of `pantheon.ei.supported_vary_headers`- are returned.
 
 #### Return
 
-__(array)__ An array of the vary headers supported by the plugin.
+_(array)_ An array of the vary headers supported by the plugin.
 
 ### `WP\update_vary_headers`
 
-Use this function if you wish to add a custom [header name](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary#header-name) to the vary header and define any custom data.
+Use this function if you want to add a custom [header name](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary#header-name) to the vary header and define any custom data.
 
 #### Parameters
 
-`$key` _(array)_ Key for the header, or array of keys.
+<dl>
 
-`$data` _(array)_ Data to pass to the HeaderData class.
+<dt>`$key` (array)</dt>
+
+<dd>
+
+  Key for the header, or array of keys.
+
+</dd>
+
+<dt>`$data` (array)</dt>
+
+<dd>
+
+Data to pass to the HeaderData class.
+
+</dd>
+
+</dl>
 
 #### Example
 
@@ -73,7 +87,7 @@ Validates header data received from the CDN for any supported vary headers, incl
 
 #### Return
 
-__(bool)__ Whether Edge Integrations have been configured and the CDN is returning data.
+_(bool)_ Lets you know whether Edge Integrations have been configured and the CDN is returning data.
 
 #### Example
 
@@ -95,7 +109,17 @@ Fires immediately after the `pantheon-ei` script is enqueued.
 
 #### Parameters
 
-`$args` _(array)_ An arguments array containing `plugin_version` (the `PANTHEON_EDGE_INTEGRATIONS_VERSION` value) and `plugin_file` (the `PANTHEON_EDGE_INTEGRATIONS_FILE` value).
+<dl>
+
+<dt>`$args` (array)</dt>
+
+<dd>
+
+An argument array containing `plugin_version` (the `PANTHEON_EDGE_INTEGRATIONS_VERSION` value) and `plugin_file` (the `PANTHEON_EDGE_INTEGRATIONS_FILE` value).
+	
+</dd>
+
+</dl>
 
 #### Example
 
@@ -112,17 +136,17 @@ function after_enqueue_script( array $args ) {
 }
 ```
 
-## Filter reference
+## Filter Reference
 
 ### `pantheon.ei.supported_vary_headers`
 
 Allows developers to modify the list of vary headers that are supported by the plugin.
 
-Array keys are the vary headers, and the values are whether or not they are supported.
+Array keys are the vary headers, and the values tell you whether or not they are supported.
 
 #### Parameters
 
-__(array)__ An array of vary headers and whether or not they are supported. The default values are below:
+_(array)_ An array of vary headers and whether or not they are supported. The default values are below:
 
 ```php
 $vary_headers = [
@@ -138,6 +162,7 @@ $vary_headers = [
 ```
 
 #### Example
+
 To set the country _name_ as the only supported personalization type:
 
 ```php
@@ -162,7 +187,7 @@ function filter_vary_headers( array $vary_headers ) {
 }
 ```
 
-To set the vary headers to not be sent until consent has been granted (see also [Pantheon Edge Integrations Consent Management](https://github.com/pantheon-systems/pantheon-edge-integrations-consent-management)):
+To set the vary headers to not be sent until consent has been granted (refer to [Pantheon Edge Integrations Consent Management](https://github.com/pantheon-systems/pantheon-edge-integrations-consent-management) for additional information):
 
 ```php
 function check_consent() {
@@ -185,7 +210,7 @@ function do_not_send_vary_headers() : array {
 
 ### `pantheon.ei.custom_header_data`
 
-This filter is applied in the `update_vary_headers` function and allows engineers to modify the custom `HeaderData` before it's returned.
+This filter is applied in the `update_vary_headers` function and allows engineers to modify the custom `HeaderData` before it is returned.
 
 #### Parameters
 
@@ -207,11 +232,11 @@ Allows developers to filter the output of the `WP\edge_integrations_enabled()` f
 
 This can be used to force the application to think that the headers have been detected when they haven't.
 
-**Note:** This does not change whether the headers exist, output may be unexpected if this value is "true" but the headers are not present.
+**Note:** This does not change whether the headers exist; output may be unexpected if this value is `true`, but the headers are not present.
 
 #### Parameters
 
-__(bool)__ `$headers_enabled` Whether Edge Integrations have been configured and the CDN is returning data.
+_(bool)_ `$headers_enabled` Whether Edge Integrations have been configured and the CDN is returning data.
 
 #### Example
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,8 +1,8 @@
-# WordPress Edge Integrations: API
+# WordPress Edge Integrations: Main
 
 ## Namespace: `Pantheon\EI\WP`
 
-The namespace for the analytics functionality is `Pantheon\EI\WP`. When using functions that are part of this namespace, it is recommended that you `use` the namespace at the top of your file.
+The base namespace for the WordPress Edge Integrations plugin is `Pantheon\EI\WP`. When using functions that are part of this namespace, it is recommended that you `use` the namespace at the top of your file.
 
 ```php
 use Pantheon\EI\WP;

--- a/docs/main.md
+++ b/docs/main.md
@@ -219,6 +219,6 @@ __(bool)__ `$headers_enabled` Whether Edge Integrations have been configured and
 // Force Edge Integrations to appear enabled. This will disable the notice that appears when the headers are not detected.
 add_filter( 'pantheon.ei.enabled', '__return_true' );
 
-// Force Edge Integrations to appear disabled. This display the notice that appears when the headers are not detected. It will not change whether Edge Integrations functions will work.
+// Force Edge Integrations to appear disabled. This displays the notice that appears when the headers are not detected. It will not change whether Edge Integrations functions will work.
 add_filter( 'pantheon.ei.enabled', '__return_false' );
 ```

--- a/docs/main.md
+++ b/docs/main.md
@@ -185,7 +185,7 @@ function do_not_send_vary_headers() : array {
 
 ### `pantheon.ei.custom_header_data`
 
-This filter is applied in the `update_vary_headers` function and allows engineers to modify the custom `HeaderData` before the it's returned.
+This filter is applied in the `update_vary_headers` function and allows engineers to modify the custom `HeaderData` before it's returned.
 
 #### Parameters
 


### PR DESCRIPTION
This adds API documentation to the  WordPress EI SDK. Because the main entrypoint for docs around the base `Pantheon\EI\WP` namespace were at `api.md` this also involved renaming that (to `main.md`) and refactoring `api.md` to cover the actual WP REST API integration.

Not included in this PR but still part of the work is updating the API documentation at [Stoplight](https://pantheon.stoplight.io/docs/edge-integrations/fed9ddb2a5046-ei) to match current spec and ensure that links to Stoplight API reference included in the SDK docuemntation is updated.